### PR TITLE
Fix debug-output, make it optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ gulp.src(['**/*.scss'])
 
 If you use gulp-watch set endless to true.
 
+#### verbose
+
+- Type: Boolean
+- Default: false
+
+If you want to see the executed scss-lint command for debugging purposes, set this to true.
+
 ## Excluding
 
 To exclude files you should use the gulp.src ignore format '!filePath''

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,8 @@ var gulpScssLint = function (options) {
               'reporterOutput',
               'customReport',
               'maxBuffer',
-              'endless'];
+              'endless',
+              'verbose'];
 
   options = options || {};
 
@@ -59,7 +60,10 @@ var gulpScssLint = function (options) {
   }
 
   function execCommand(command) {
-    console.log(command);
+    if (options.verbose) {
+      console.log(command);
+    }
+
     var commandOptions = {
       env: process.env,
       cwd: process.cwd(),


### PR DESCRIPTION
After updating gulp-scss-lint to version 0.1.5, when running the task with a very basic configuration:

```
gulp.task('scsslint', function () {
  return gulp.src(config.src + config.sass + '**/*.scss')
    .pipe(scsslint({
      config: '.scss-lint.yml'
    }));
});
```

the output on the command-line is overly verbose, showing me the whole command executed, with all files to be parsed:

```
[18:09:54] Starting 'scsslint'...
scss-lint /Users/me/Sites/dev/source/scss/main.scss /Users/me/Sites/dev/source/scss/base/_base.scss /Users/me/Sites/dev/source/scss/base/_fonts.scss [...]  --config .scss-lint.yml --format XML
[18:09:58] Finished 'scsslint' after 3.96 s
```

I made this 'bug' a feature with an additonal option :-)