### PR TITLE
Improve default reporter

### DIFF
--- a/src/reporters.js
+++ b/src/reporters.js
@@ -24,8 +24,10 @@ exports.defaultReporter = function (file) {
     gutil.log(colors.cyan(file.scsslint.issues.length) + ' issues found in ' + colors.magenta(file.path));
 
     file.scsslint.issues.forEach(function (issue) {
-      var severity = issue.severity === 'warning' ? 'W' : 'E';
-      var logMsg = colors.cyan(file.path) + ':' + colors.magenta(issue.line) + ' [' + severity + '] ' + issue.reason;
+      var severity = issue.severity === 'warning' ? colors.yellow(' [W] ') : colors.red(' [E] ');
+      var linter = issue.linter ? (issue.linter + ': ') : ''
+      var logMsg =
+        colors.cyan(file.relative) + ':' + colors.magenta(issue.line) + severity + colors.green(linter) + issue.reason;
 
       gutil.log(logMsg);
     });

--- a/test/reporters.js
+++ b/test/reporters.js
@@ -101,6 +101,7 @@ describe('reporters', function() {
     fakeFile.scsslint.issues = [
       {"severity": "warning",
        "line": 10,
+       "linter": "some linter",
        "reason": "some reasone"},
       {"severity": "error",
        "line": 13,
@@ -114,10 +115,10 @@ describe('reporters', function() {
 
     var firstCall = log.withArgs(colors.cyan(fakeFile.scsslint.issues.length) + ' issues found in ' + colors.magenta(fakeFile.path)).calledOnce;
 
-    var secondCall = log.withArgs(colors.cyan(fakeFile.path) + ':' + colors.magenta(fakeFile.scsslint.issues[0].line) + ' [W] ' + fakeFile.scsslint.issues[0].reason).calledOnce;
+    var secondCall = log.withArgs(colors.cyan(fakeFile.relative) + ':' + colors.magenta(fakeFile.scsslint.issues[0].line) + colors.yellow(' [W] ') + colors.green(fakeFile.scsslint.issues[0].linter + ': ') + fakeFile.scsslint.issues[0].reason).calledOnce;
 
 
-    var thirdCall = log.withArgs(colors.cyan(fakeFile.path) + ':' + colors.magenta(fakeFile.scsslint.issues[1].line) + ' [E] ' + fakeFile.scsslint.issues[1].reason).calledOnce;
+    var thirdCall = log.withArgs(colors.cyan(fakeFile.relative) + ':' + colors.magenta(fakeFile.scsslint.issues[1].line) + colors.red(' [E] ') + fakeFile.scsslint.issues[1].reason).calledOnce;
 
     expect(firstCall).to.be.ok;
     expect(secondCall).to.be.ok;


### PR DESCRIPTION
Let the default reporter's output be identical to sccs-lint's output and increase readability by printing relative file paths.