### PR TITLE
use `sync-exec` package instead of deprecated `execSync`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "dargs": "~3.0.0",
     "event-stream": "~3.2.2",
-    "execSync": "^1.0.2",
+    "sync-exec": "~0.5.0",
     "gulp-util": "~3.0.3",
     "pretty-data": "^0.40.0",
     "xml2js": "^0.4.4"

--- a/src/index.js
+++ b/src/index.js
@@ -72,13 +72,13 @@ var gulpScssLint = function (options) {
           fn(error, result.stdout);
         }
       } else {
-        var sh = require('execSync');
+        var exec = require('sync-exec');
 
-        var result = sh.exec(command);
+        var result = exec(command);
         var error;
 
-        if (result.code) {
-          error = {code: result.code};
+        if (result.status) {
+          error = {code: result.status};
         }
 
         fn(error, result.stdout);


### PR DESCRIPTION
Fixes #25