### PR TITLE
Export defaultReporter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -229,6 +229,7 @@ var gulpScssLint = function (options) {
   return stream;
 };
 
-gulpScssLint.failReporter = reporters.failReporter
+gulpScssLint.failReporter = reporters.failReporter;
+gulpScssLint.defaultReporter = reporters.defaultReporter;
 
 module.exports = gulpScssLint;


### PR DESCRIPTION
I'm writing a checker using scss-lint, and I'd like to be able to use a custom reporter but *also* use the default reporter.

I'm using `gulp-notify` to create a desktop notification, but I don't want to reinvent the wheel and write a new console notification.

I want to define a custom reporter like this:

    var scsslint = require('gulp-scss-lint');
    
    if (!file.scsslint.success) {
      notifier.notify({ options});
      scsslint.defaultReporter(file);
    }

I think this line is all I need to make that possible. Seem reasonable?