### PR TITLE
Replace XML formatter with Checkstyle formatter.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
-gem 'scss-lint'
+gem 'scss_lint'
+gem 'scss_lint_reporter_checkstyle'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,22 @@
+GIT
+  remote: https://github.com/brigade/scss-lint
+  revision: dc84c5d01a94c3eefe2045d07d20782478a14950
+  ref: dc84c5d
+  specs:
+    scss_lint (0.38.0)
+      rainbow (~> 2.0)
+      sass (~> 3.4.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
     rainbow (2.0.0)
-    sass (3.4.5)
-    scss-lint (0.33.0)
-      rainbow (~> 2.0)
-      sass (~> 3.4.5)
+    sass (3.4.13)
+    scss_lint_reporter_checkstyle (0.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  scss-lint
+  scss_lint!
+  scss_lint_reporter_checkstyle

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,8 @@ var gulpScssLint = function (options) {
 
   options = options || {};
 
-  options.format = 'XML';
+  options.format = 'Checkstyle';
+  options.require = 'scss_lint_reporter_checkstyle';
 
   if (options.exclude) {
     throw new gutil.PluginError(PLUGIN_NAME, "You must use gulp src to exclude");
@@ -136,10 +137,10 @@ var gulpScssLint = function (options) {
   }
 
   function getFileReport(file, report) {
-    if (report.lint.file) {
-      for (var i = 0; i < report.lint.file.length; i++) {
-        if (report.lint.file[i].$.name === file.path) {
-          return report.lint.file[i];
+    if (report.checkstyle.file) {
+      for (var i = 0; i < report.checkstyle.file.length; i++) {
+        if (report.checkstyle.file[i].$.name === file.path) {
+          return report.checkstyle.file[i];
         }
       }
     }
@@ -153,10 +154,10 @@ var gulpScssLint = function (options) {
       lintResult = defaultLintResult();
       fileReport = getFileReport(files[i], report);
 
-      if (fileReport && fileReport.issue.length) {
+      if (fileReport && fileReport.error.length) {
         lintResult.success = false;
 
-        fileReport.issue.forEach(function (issue) {
+        fileReport.error.forEach(function (issue) {
           issue = issue.$;
 
           var severity = issue.severity === 'warning' ? 'W' : 'E';

--- a/test/main.js
+++ b/test/main.js
@@ -33,7 +33,7 @@ describe('gulp-scss-lint', function() {
         expect(file.scsslint.issues[0].column).to.exist;
         expect(file.scsslint.issues[0].length).to.exist;
         expect(file.scsslint.issues[0].severity).to.exist;
-        expect(file.scsslint.issues[0].reason).to.exist;
+        expect(file.scsslint.issues[0].message).to.exist;
       })
       .once('end', function() {
         done();
@@ -198,7 +198,7 @@ describe('gulp-scss-lint', function() {
     stream
       .on('data', function (data) {
         expect(data.contents.toString('utf-8')).to.have.string('<?xml');
-        expect(data.contents.toString('utf-8')).to.have.string('</lint>');
+        expect(data.contents.toString('utf-8')).to.have.string('</checkstyle>');
         expect(data.path).to.be.equal('test/fixtures/test.xml');
       })
       .once('end', function() {


### PR DESCRIPTION
Not sure if this is the approach you want to take as it adds a gem dependency, but it solves the issue created by the [removal of the XML formatter](https://github.com/brigade/scss-lint/commit/c6df8d7940d403d3fa4e315a6b93ef5dd3141f14) from scss-lint.