### PR TITLE
Fixing documentation typo regarding the gem dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install gulp-scss-lint --save-dev
 
 This plugin requires Ruby and [scss-lint](https://github.com/causes/scss-lint)
 ```shell
-gem install scss_lint
+gem install scss-lint
 ```
 
 ## Usage


### PR DESCRIPTION
Updating the documentation from scss_lint to scss-lint, fixes #59