### PR TITLE
Fix error handing when Ruby/scss-lint missing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ var gulpScssLint = function (options) {
       }, function(e) {
         var err = new gutil.PluginError(PLUGIN_NAME, e);
 
-        stream.emit('error', err);
+        stream.emit('error', e);
         stream.emit('end');
       })
       .done(function(e) {});


### PR DESCRIPTION
fixes #75

The "Fatal undefined" error message is being reported instead of "You need to have Ruby and scss-lint gem installed" due to the misspelling of a variable in the `lint` function in index.js. This has shown up in other projects that depend on gulp-scss-lint, e.g. https://github.com/ionic-team/ionic/issues/10358
