### PR TITLE
Drop dependency on sync-exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "pretty-data": "^0.40.0",
     "shell-escape": "^0.2.0",
     "slash": "^2.0.0",
-    "sync-exec": "~0.6.2",
     "vinyl": "^2.2.0",
     "vinyl-fs": "^3.0.3",
     "xml2js": "^0.4.16"

--- a/src/command.js
+++ b/src/command.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var execSync = require('sync-exec');
 var Promise = require('bluebird');
 var checkstyle = require('./checkstyle');
 var dargs = require('dargs');
@@ -50,7 +49,7 @@ function execCommand(command, options) {
     };
 
     if (options.sync || options.endless) {
-      var commandResult = execSync(command);
+      var commandResult = child_process.execSync(command);
       var error = null;
 
       if (commandResult.status) {


### PR DESCRIPTION
The `sync-exec` package has a [minor vulnerability](https://www.npmjs.com/advisories/310) with no fix. The vulnerability itself is somewhat laughable in this case, as it would potentially allow low-privileged users see that you are running commands to lint your SCSS files by looking at the output to `/tmp` (oh, the horror!), but it nonetheless triggers an annoying warning anytime you install the `gulp-scss-lint` package as this vulnerability is associated with `sync-exec`.

Since `sync-exec` was being utilized for Node versions prior v0.12, where [`child_process.execSync`](https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options) was not available, its usage is no longer required. I can see that the Travis config uses Node v6+ and the older versions of Node have long been [end of life](https://github.com/nodejs/Release).

I did not commit changes to `package-lock.json` because in npm 6+ they started adding carets and tildes to all versions, which would have resulted in a massively unnecessary diff between what's currently in master and what's in this patch.